### PR TITLE
fix eov case

### DIFF
--- a/asset/resources/filters.json
+++ b/asset/resources/filters.json
@@ -20,7 +20,7 @@
                     "en":"Temperature"
                 },
                 "ckantext":["Sea Surface Temperature", "Potential Temperature", "Sub Surface Temperature"],
-                "eovs": [ "seasurfacetemperature", "potentialtemperature", "subsurfacetemperature" ],
+                "eovs": [ "seaSurfaceTemperature", "potentialTemperature", "subSurfaceTemperature" ],
                 "enabled": true
             },
             {
@@ -32,7 +32,7 @@
                     "en":"Wind"
                 },
                 "ckantext":["wind"],
-                "eovs": [ "seasurfacetemperature", "potentialtemperature", "subsurfacetemperature" ],
+                "eovs": [ "seaSurfaceTemperature", "potentialTemperature", "subSurfaceTemperature" ],
                 "enabled": true
             },
             {


### PR DESCRIPTION
A few EOV's aren't matching to their records in CKAN because the case isn't camelCase like the others, and it seems CKAN API (Solr) is case sensitive.