### PR TITLE
display datasets consisting of a single point

### DIFF
--- a/asset/js/asset_ckan.js
+++ b/asset/js/asset_ckan.js
@@ -544,8 +544,17 @@ function AddDisplayCKANClusterIcon( data )
        {
             addGeometryToCache(r['id'], objspatial);
            // Create geometry feature as polygone (rect extent)
-           var feature = new ol.Feature({
-            geometry: new ol.geom.Point(getCenterOfCoordinates(objspatial['coordinates'][0]))
+           let centerPoint;
+
+           if(objspatial['type']==='Point') {
+               centerPoint = objspatial['coordinates'];
+            }
+           else {
+               centerPoint = getCenterOfCoordinates(objspatial['coordinates'][0]);
+            }
+
+            feature = new ol.Feature({
+                geometry: new ol.geom.Point(centerPoint)
             });
             feature.setId(r['id']);
             feature.getGeometry().transform('EPSG:4326', 'EPSG:3857');
@@ -564,23 +573,24 @@ function AddDisplayCKANClusterIcon( data )
    // update map
 }
 
-function datasetHasSpatial(data)
+function getDatasetSpatialData(data)
+{   let spatial;
+    if (data["spatial"])
 {
-    if (data["spatial"] != undefined && data["spatial"] !== "")
-    {
-       return true;
+        spatial = data["spatial"];
     }
-    else if ( data['extras'] != undefined)
+    else if ( data['extras'] )
     {
         // slgo + extension spatial schema
         data['extras'].forEach( function(entry)
         {
             if ( entry['key'] == 'spatial')
             {
-                return true;
+                spatial = entry['value'];
             }
         });
     }
+    if(spatial) return JSON.parse(spatial);
     return false;
 }
 
@@ -953,10 +963,10 @@ function generateCompleteDetailsPanel( dataset )
 }
 
 function generateDetailsPanel( dataset ) //, language, dataset_id, title, description, provider, link_url, prov_url)
-{
+{   let spatial = getDatasetSpatialData(dataset);
     let ret_html = "<div id='" + dataset["id"] + "'class='asset_details'>";
     // check if geomeetry details available for this dataset
-    if ( datasetHasSpatial(dataset) )
+    if ( spatial && spatial['type'] === 'Polygon')
     {
         ret_html += '<a href="#" onclick="showInGeometryLayer(\'' + dataset["id"] + '\')" title="' + i18nStrings.getUIString("map") + '"><img class="map-marker" src="/asset/images/map-marker.svg"></a>';
     }


### PR DESCRIPTION
Adds support for datasets with spatial defined by one point. Hides the 'view polygon' button on those datasets