### PR TITLE
remove 'Dataset title' text in sidebar

### DIFF
--- a/asset/js/asset_ckan.js
+++ b/asset/js/asset_ckan.js
@@ -970,15 +970,10 @@ function generateDetailsPanel( dataset ) //, language, dataset_id, title, descri
     {
         ret_html += '<a href="#" onclick="showInGeometryLayer(\'' + dataset["id"] + '\')" title="' + i18nStrings.getUIString("map") + '"><img class="map-marker" src="/asset/images/map-marker.svg"></a>';
     }
-    ret_html += '<h3 class="details_label">' + '<a data-toggle="collapse" href="#' + dataset["id"] + '_collapse' + '" role="button" onclick="showDatasetDetailDescription(\'' + dataset["id"] + '\');">' + i18nStrings.getUIString("dataset_title") + '</a></h3>'; 
-    if ( ckan_server.support_multilanguage)
-    {
-        ret_html += "<p class='details_text bottom-0'>" + i18nStrings.getTranslation(dataset['title_translated']) + "</p>";
-    }
-    else
-    {
-        ret_html += "<p class='details_text bottom-0'>" + dataset['title'] + "</p>";
-    }
+    
+    const title = ckan_server.support_multilanguage ? i18nStrings.getTranslation(dataset['title_translated']) : dataset['title'];
+    ret_html += '<h3 class="details_label">' + '<a data-toggle="collapse" href="#' + dataset["id"] + '_collapse' + '" role="button" onclick="showDatasetDetailDescription(\'' + dataset["id"] + '\');">' + title + '</a></h3>'; 
+    
     // ret_html += '<div class="asset-actions">';
     // ret_html += '<span class="details_label">Information:</span>';
     // ret_html += '<a data-toggle="collapse" href="#' + dataset["id"] + '_collapse' + '" role="button" onclick="showDatasetDetailDescription(\'' + dataset["id"] + '\');">' + i18nStrings.getUIString("details") + '</a>';


### PR DESCRIPTION
Just an idea, feel free to reject, but I thought we could remove the text 'Titre du jeu de connées'/'Dataset title' from the sidebar. It would look like this instead:

<img width="474" alt="Screen Shot 2019-11-28 at 11 42 18 AM" src="https://user-images.githubusercontent.com/26209011/69829319-5da42980-11d4-11ea-8265-714365722a12.png">
