### PR TITLE
handle duplicate points by spreading them out a bit

### DIFF
--- a/asset/js/asset_ckan.js
+++ b/asset/js/asset_ckan.js
@@ -811,9 +811,23 @@ function getStyleFromClusterConfig( config, nbrElem)
     ret['circle_radius'] = config['minimum']['circle_radius'] * minweight + config['maximum']['circle_radius'] * maxweight;
     return ret;
 }
+// if newCoords exists in existingCoordsArray, return a coordinate that is slightly different
+function moveCoordsSlightlyIfDuplicate(newCoords, existingCoordsArray) {
+                    
+    const [lat, long] = newCoords;
+
+    const numberMatchingCoords = existingCoordsArray.filter(function (coord) { return coord[0] == lat && coord[1] == long; }).length
+    
+    if (numberMatchingCoords > 0) {
+        const movedCoords = [lat, long + numberMatchingCoords * 0.001]
+        return movedCoords;
+    }
+    return newCoords;
+}
 
 function displayCKANClusterIcon( data )
 {
+    const allCoords = [];
     // for each, look for the spatial extra
     let i = 0;
     let results = data['result']['results'];
@@ -844,9 +858,12 @@ function displayCKANClusterIcon( data )
             addGeometryToCache(r['id'], objspatial);
             // Create geometry feature as polygone (rect extent)
             //new Feature(new Point(coordinates));
+            const coordsToAdd = getCentroidOfSpatial(objspatial)
             var pointfeature = new ol.Feature({
-                geometry: new ol.geom.Point(getCentroidOfSpatial(objspatial))
+                
+                geometry: new ol.geom.Point(moveCoordsSlightlyIfDuplicate(coordsToAdd, allCoords))
             });
+            allCoords.push(coordsToAdd)
             pointfeature.setId(r['id']);
             pointfeature.getGeometry().transform('EPSG:4326', 'EPSG:3857');
             // set id to link to description panel


### PR DESCRIPTION
If there are multiple datasets with the same coordinates. this moves the latitude slightly of the duplicated coords so they are spread out